### PR TITLE
Replace singular cd aind-ephys-pipeline/pipeline  in two steps

### DIFF
--- a/docs/source/deployments.rst
+++ b/docs/source/deployments.rst
@@ -24,7 +24,8 @@ Configuration
 .. code-block:: bash
 
    git clone https://github.com/AllenNeuralDynamics/aind-ephys-pipeline.git
-   cd aind-ephys-pipeline/pipeline
+   cd aind-ephys-pipeline
+   cd pipeline
 
 2. Copy and modify the SLURM configuration:
 
@@ -98,7 +99,8 @@ Running Locally
 .. code-block:: bash
 
    git clone https://github.com/AllenNeuralDynamics/aind-ephys-pipeline.git
-   cd aind-ephys-pipeline/pipeline
+   cd aind-ephys-pipeline
+   cd pipeline
 
 2. Run the pipeline:
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -87,6 +87,7 @@ Clone the pipeline repository:
 .. code-block:: bash
 
    git clone https://github.com/AllenNeuralDynamics/aind-ephys-pipeline.git
-   cd aind-ephys-pipeline/pipeline
+   cd aind-ephys-pipeline
+   cd pipeline
 
 The pipeline is now ready to be configured and run on your chosen platform.


### PR DESCRIPTION
This is necessary to avoid operator error which types commands instead of cut and paste. We already two such operators (yours truly included) who ran into the trap of ending up in the root folder (name is long enough to lose track of levels of nesting)