### PR TITLE
Split environment variable definitions before calling nextflow

### DIFF
--- a/docs/source/deployments.rst
+++ b/docs/source/deployments.rst
@@ -106,8 +106,8 @@ Running Locally
 
 .. code-block:: bash
 
-   DATA_PATH=$PWD/../data;
-   RESULTS_PATH=$PWD/../results;
+   DATA_PATH=$PWD/../data
+   RESULTS_PATH=$PWD/../results
    nextflow -C nextflow_local.config -log $RESULTS_PATH/nextflow/nextflow.log \
       run main_multi_backend.nf \
       --n_jobs 8 -resume


### PR DESCRIPTION
Otherwise, the log file path will not be specified correctly