### PR TITLE
Refactor: eliminate git cloning duplication with unified helper function for cloning

### DIFF
--- a/pipeline/main_multi_backend.nf
+++ b/pipeline/main_multi_backend.nf
@@ -4,6 +4,25 @@ nextflow.enable.dsl = 2
 params.ecephys_path = DATA_PATH
 params.params_file = null
 
+// Git repository prefix - can be overridden via command line or environment variable
+params.git_repo_prefix = System.getenv('GIT_REPO_PREFIX') ?: 'https://github.com/AllenNeuralDynamics/aind-'
+
+// Helper function for git cloning
+def gitCloneFunction = '''
+clone_repo() {
+    local repo_url="$1"
+    local commit_hash="$2"
+
+    echo "cloning git repo: \${repo_url} (commit: \${commit_hash})..."
+
+    git clone "\${repo_url}" capsule-repo
+    git -C capsule-repo -c core.fileMode=false checkout "\${commit_hash}" --quiet
+
+    mv capsule-repo/code capsule/code
+    rm -rf capsule-repo
+}
+'''
+
 println "DATA_PATH: ${DATA_PATH}"
 println "RESULTS_PATH: ${RESULTS_PATH}"
 
@@ -176,10 +195,8 @@ process job_dispatch {
     TASK_DIR=\$(pwd)
 
     echo "[${task.tag}] cloning git repo..."
-    git clone "https://github.com/AllenNeuralDynamics/aind-ephys-job-dispatch.git" capsule-repo
-    git -C capsule-repo -c core.fileMode=false checkout ${versions['JOB_DISPATCH']}  --quiet
-    mv capsule-repo/code capsule/code
-    rm -rf capsule-repo
+    ${gitCloneFunction}
+    clone_repo "${params.git_repo_prefix}ephys-job-dispatch.git" "${versions['JOB_DISPATCH']}"
 
     echo "[${task.tag}] running capsule..."
     cd capsule/code
@@ -224,10 +241,8 @@ process preprocessing {
     fi
 
     echo "[${task.tag}] cloning git repo..."
-    git clone "https://github.com/AllenNeuralDynamics/aind-ephys-preprocessing.git" capsule-repo
-    git -C capsule-repo -c core.fileMode=false checkout ${versions['PREPROCESSING']}  --quiet
-    mv capsule-repo/code capsule/code
-    rm -rf capsule-repo
+    ${gitCloneFunction}
+    clone_repo "${params.git_repo_prefix}ephys-preprocessing.git" "${versions['PREPROCESSING']}"
 
     echo "[${task.tag}] running capsule..."
     cd capsule/code
@@ -265,10 +280,8 @@ process spikesort_kilosort25 {
     fi
 
     echo "[${task.tag}] cloning git repo..."
-    git clone "https://github.com/AllenNeuralDynamics/aind-ephys-spikesort-kilosort25.git" capsule-repo
-    git -C capsule-repo -c core.fileMode=false checkout ${versions['SPIKESORT_KS25']} --quiet
-    mv capsule-repo/code capsule/code
-    rm -rf capsule-repo
+    ${gitCloneFunction}
+    clone_repo "${params.git_repo_prefix}ephys-spikesort-kilosort25.git" "${versions['SPIKESORT_KS25']}"
 
     echo "[${task.tag}] running capsule..."
     cd capsule/code
@@ -306,10 +319,8 @@ process spikesort_kilosort4 {
     fi
 
     echo "[${task.tag}] cloning git repo..."
-    git clone "https://github.com/AllenNeuralDynamics/aind-ephys-spikesort-kilosort4.git" capsule-repo
-    git -C capsule-repo -c core.fileMode=false checkout ${versions['SPIKESORT_KS4']} --quiet
-    mv capsule-repo/code capsule/code
-    rm -rf capsule-repo
+    ${gitCloneFunction}
+    clone_repo "${params.git_repo_prefix}ephys-spikesort-kilosort4.git" "${versions['SPIKESORT_KS4']}"
 
     echo "[${task.tag}] running capsule..."
     cd capsule/code
@@ -347,10 +358,8 @@ process spikesort_spykingcircus2 {
     fi
 
     echo "[${task.tag}] cloning git repo..."
-    git clone "https://github.com/AllenNeuralDynamics/aind-ephys-spikesort-spykingcircus2.git" capsule-repo
-    git -C capsule-repo -c core.fileMode=false checkout ${versions['SPIKESORT_SC2']} --quiet
-    mv capsule-repo/code capsule/code
-    rm -rf capsule-repo
+    ${gitCloneFunction}
+    clone_repo "${params.git_repo_prefix}ephys-spikesort-spykingcircus2.git" "${versions['SPIKESORT_SC2']}"
 
     echo "[${task.tag}] running capsule..."
     cd capsule/code
@@ -391,10 +400,8 @@ process postprocessing {
     fi
 
     echo "[${task.tag}] cloning git repo..."
-    git clone "https://github.com/AllenNeuralDynamics/aind-ephys-postprocessing.git" capsule-repo
-    git -C capsule-repo -c core.fileMode=false checkout ${versions['POSTPROCESSING']} --quiet
-    mv capsule-repo/code capsule/code
-    rm -rf capsule-repo
+    ${gitCloneFunction}
+    clone_repo "${params.git_repo_prefix}ephys-postprocessing.git" "${versions['POSTPROCESSING']}"
 
     echo "[${task.tag}] running capsule..."
     cd capsule/code
@@ -432,10 +439,8 @@ process curation {
     fi
 
     echo "[${task.tag}] cloning git repo..."
-    git clone "https://github.com/AllenNeuralDynamics/aind-ephys-curation.git" capsule-repo
-    git -C capsule-repo -c core.fileMode=false checkout ${versions['CURATION']} --quiet
-    mv capsule-repo/code capsule/code
-    rm -rf capsule-repo
+    ${gitCloneFunction}
+    clone_repo "${params.git_repo_prefix}ephys-curation.git" "${versions['CURATION']}"
 
     echo "[${task.tag}] running capsule..."
     cd capsule/code
@@ -478,10 +483,8 @@ process visualization {
     fi
 
     echo "[${task.tag}] cloning git repo..."
-    git clone "https://github.com/AllenNeuralDynamics/aind-ephys-visualization.git" capsule-repo
-    git -C capsule-repo -c core.fileMode=false checkout ${versions['VISUALIZATION']} --quiet
-    mv capsule-repo/code capsule/code
-    rm -rf capsule-repo
+    ${gitCloneFunction}
+    clone_repo "${params.git_repo_prefix}ephys-visualization.git" "${versions['VISUALIZATION']}"
 
     echo "[${task.tag}] running capsule..."
     cd capsule/code
@@ -529,14 +532,12 @@ process results_collector {
     fi
 
     echo "[${task.tag}] cloning git repo..."
-    git clone "https://github.com/AllenNeuralDynamics/aind-ephys-results-collector.git" capsule-repo
-    git -C capsule-repo -c core.fileMode=false checkout ${versions['RESULTS_COLLECTOR']} --quiet
-    mv capsule-repo/code capsule/code
-    rm -rf capsule-repo
+    ${gitCloneFunction}
+    clone_repo "${params.git_repo_prefix}ephys-results-collector.git" "${versions['RESULTS_COLLECTOR']}"
 
     echo "[${task.tag}] running capsule..."
     cd capsule/code
-    chmod +x run 
+    chmod +x run
     ./run --pipeline-data-path ${DATA_PATH} --pipeline-results-path ${RESULTS_PATH}
 
     echo "[${task.tag}] completed!"
@@ -572,10 +573,8 @@ process quality_control {
     fi
 
     echo "[${task.tag}] cloning git repo..."
-    git clone "https://github.com/AllenNeuralDynamics/aind-ephys-processing-qc.git" capsule-repo
-    git -C capsule-repo -c core.fileMode=false checkout ${versions['QUALITY_CONTROL']} --quiet
-    mv capsule-repo/code capsule/code
-    rm -rf capsule-repo
+    ${gitCloneFunction}
+    clone_repo "${params.git_repo_prefix}ephys-processing-qc.git" "${versions['QUALITY_CONTROL']}"
 
     echo "[${task.tag}] running capsule..."
     cd capsule/code
@@ -615,10 +614,8 @@ process quality_control_collector {
     fi
 
     echo "[${task.tag}] cloning git repo..."
-    git clone "https://github.com/AllenNeuralDynamics/aind-ephys-qc-collector.git" capsule-repo
-    git -C capsule-repo -c core.fileMode=false checkout ${versions['QUALITY_CONTROL_COLLECTOR']} --quiet
-    mv capsule-repo/code capsule/code
-    rm -rf capsule-repo
+    ${gitCloneFunction}
+    clone_repo "${params.git_repo_prefix}ephys-qc-collector.git" "${versions['QUALITY_CONTROL_COLLECTOR']}"
 
     echo "[${task.tag}] running capsule..."
     cd capsule/code
@@ -656,10 +653,8 @@ process nwb_subject {
     fi
 
     echo "[${task.tag}] cloning git repo..."
-    git clone "https://github.com/AllenNeuralDynamics/aind-subject-nwb" capsule-repo
-    git -C capsule-repo -c core.fileMode=false checkout ${versions['NWB_SUBJECT']} --quiet
-    mv capsule-repo/code capsule/code
-    rm -rf capsule-repo
+    ${gitCloneFunction}
+    clone_repo "${params.git_repo_prefix}subject-nwb.git" "${versions['NWB_SUBJECT']}"
 
     echo "[${task.tag}] running capsule..."
     cd capsule/code
@@ -698,10 +693,8 @@ process nwb_ecephys {
     fi
 
     echo "[${task.tag}] cloning git repo..."
-    git clone "https://github.com/AllenNeuralDynamics/aind-ecephys-nwb.git" capsule-repo
-    git -C capsule-repo -c core.fileMode=false checkout ${versions['NWB_ECEPHYS']} --quiet
-    mv capsule-repo/code capsule/code
-    rm -rf capsule-repo
+    ${gitCloneFunction}
+    clone_repo "${params.git_repo_prefix}ecephys-nwb.git" "${versions['NWB_ECEPHYS']}"
 
     echo "[${task.tag}] running capsule..."
     cd capsule/code
@@ -740,10 +733,8 @@ process nwb_units {
     mkdir -p capsule/scratch
 
     echo "[${task.tag}] cloning git repo..."
-    git clone "https://github.com/AllenNeuralDynamics/aind-units-nwb.git" capsule-repo
-    git -C capsule-repo -c core.fileMode=false checkout ${versions['NWB_UNITS']}  --quiet
-    mv capsule-repo/code capsule/code
-    rm -rf capsule-repo
+    ${gitCloneFunction}
+    clone_repo "${params.git_repo_prefix}units-nwb.git" "${versions['NWB_UNITS']}"
 
     if [[ ${params.executor} == "slurm" ]]; then
         echo "[${task.tag}] allocated task time: ${task.time}"


### PR DESCRIPTION
This is just an initial attempt since there could be much more of refactoring to reduce duplication etc.
But it all depends on 
- #70 

kinda so ideally it should not disturb your workflow much.  But it might establish the first steps for making pipelines "flexible" enough more easily to provide an "offline" solution for

- #69 
 
Both main.nf and main_multi_backend.nf had extensive duplication in their git cloning logic across all processes. This refactoring introduces:

- Added params.git_repo_prefix parameter to externalize repository URL prefixes
- Created gitCloneFunction helper for main.nf (11 processes refactored)
- Created gitCloneFunction helper for main_multi_backend.nf (14 processes refactored)
- Eliminated ~120 lines of duplicated code across both pipelines
- Repository prefix can now be configured via environment variable, CLI parameter, or config file

main.nf changes:
- Default prefix: https://$GIT_ACCESS_TOKEN@$GIT_HOST/capsule-
- Helper handles git version checking and conditional --filter=tree:0 flag
- All 11 capsule processes now use clone_capsule_repo(repo_id, branch)

main_multi_backend.nf changes:
- Default prefix: https://github.com/AllenNeuralDynamics/aind-
- Helper handles commit hash-based checkout with quiet mode
- All 14 processes now use clone_repo(repo_name, commit_hash)

Benefits:
- Single source of truth for git cloning logic
- Easy to test with different git repositories
- Simplified maintenance and consistent behavior across all processes
- Flexible deployment to different git hosts without code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

<details>
<summary>Original user request to claude:
</summary> 

Here we have two nextflow pipelines -- main.nf and main_multi_backend.nf. I see that they have lots of duplication in cloning of external repos within their processes. In both pipelines they do something really similar but use different source locations for git repos, and the names. So it is https://$GIT_ACCESS_TOKEN@$GIT_HOST/capsule- prefixes in main.nf and https://github.com/AllenNeuralDynamics/aind- in main_multi_backend.nf and then actual identifiers differ from numeric for those 'capsule-' and then actual names when from github. I would like to refactor them potentially indepently to start with so they would use internally some singular helper to clone from that uniform prefix they have. Then also differ in terms of which branch to use - so besides repo identifier should be passed into the function. Please review those pipelines and plan the uniform refactoring for both of them. Also in both provision specific of that prefix to be provided from outside of the pipeline ---

```
