### PR TITLE
Change NWB writing backend options to zarr and hdf5

### DIFF
--- a/docs/source/parameters.rst
+++ b/docs/source/parameters.rst
@@ -113,7 +113,7 @@ NWB Ecephys Parameters
 .. code-block:: bash
 
    --nwb_ecephys_args "
-     --backend {pynwb,hdmf}    # Backend to use for NWB writing (if pipeline 'input' is not NWB)
+     --backend {zarr,hdf5}     # Backend to use for NWB writing (default: zarr)
      --skip-lfp                # Skip LFP electrical series
      --write-raw               # Write RAW electrical series
      --lfp_temporal_factor N   # Temporal subsampling factor


### PR DESCRIPTION
@alejoe91 Surely this is what is meant for this parameter, based on usage in https://github.com/AllenNeuralDynamics/aind-ecephys-nwb/blob/main/code/run_capsule.py#L250?

Since the imports of the contexts (`pynwb` vs. `hdmf_zarr`) are hard-coded above and cannot be directly modified in the script

Note recent PyNWB versions have that [`read_nwb`](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/src/pynwb/__init__.py#L544) method that automatically determines which context to use as well